### PR TITLE
Adds more details on using `unit_parse` together with `pint`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,12 +360,27 @@ print(result)  # Quantity("100 mole")
 
 ---
 ---
+
 ## Notes
 
 ### Pint UnitRegistry
-Pint's requires a Unit Registry to be defined. However, Unit Registries are not interoperable and will throw 
-errors if a unit from one registry is used in another. Unit_Parse will go looking to see if one has been created, 
+
+Pint's requires a Unit Registry to be defined. However, Unit Registries are not interoperable and will throw
+errors if a unit from one registry is used in another. Unit_Parse will go looking to see if one has been created,
 and if it hasn't we will make one!
 
-So if your project uses Pint already, make sure you import Pint and define the UnitRegistry before importing unit_parse.
+So if your project uses Pint already, make sure you import Pint and define the `UnitRegistry` before
+importing `unit_parse`. You must also define `Unit` and `Quantity` to make the registry discoverable.
+
+```python
+import pint
+
+u = pint.UnitRegistry()
+U = Unit = u.Unit
+Q = Quantity = u.Quantity
+
+from unit_parse import parser
+
+# your code from here…
+```
     


### PR DESCRIPTION
It took me quite a while to figure out that I have to define `Unit` and `Quantity` based on the `Pint` registry to make it discoverable by `unit_parse`. I basically only figured it out reading your test cases (`test_pint.py`). So I thought it might be good to add that hint to your documentation as well.