### PR TITLE
Freeze pint version to a known good one (0.19)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
 zip_safe = no
 include_package_data = true
 install_requires =
-    pint>=0.18
+    pint==0.19
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
## Issue
It seems that at some point (after Pint version 0.19) the mechanism for loading units in Pint has been changed. Tested on all python versions from 3.9 to 3.11, all leading to the following Exception on `unit_parse` import:
```python
Python 3.9.17 (main, Jun  8 2023, 00:00:00) 
[GCC 12.3.1 20230508 (Red Hat 12.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import unit_parse
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/unit_parse/__init__.py", line 2, in <module>
    from unit_parse.config import config, Unit, Quantity, Q, U
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/unit_parse/config.py", line 59, in <module>
    u = check_for_pint()
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/unit_parse/config.py", line 52, in check_for_pint
    u_ = pint.UnitRegistry(autoconvert_offset_to_baseunit=True,
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/facets/plain/registry.py", line 138, in __call__
    obj._after_init()
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/facets/system/registry.py", line 78, in _after_init
    super()._after_init()
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/facets/group/registry.py", line 64, in _after_init
    super()._after_init()
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/facets/plain/registry.py", line 309, in _after_init
    loaded_files = self.load_definitions(self._filename)
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/facets/plain/registry.py", line 552, in load_definitions
    for definition in self._def_parser.iter_parsed_project(parsed_project):
  File "/home/vasil/.venv39/lib64/python3.9/site-packages/pint/delegates/txt_defparser/defparser.py", line 112, in iter_parsed_project
    raise stmt
pint.delegates.txt_defparser.common.DefinitionSyntaxError: Derived dimensions cannot have aliases.
    231,0-231,40 [velocity] = [length] / [time] = [speed]
    /home/vasil/.venv39/lib/python3.9/site-packages/unit_parse/support_files/constants_en.txt
```

## Fix explanation

Freezing to a specific version is a temporary fix, but it allows the package to be used until a proper resolution is found.

## Testing fix

```
$ python3 -m venv .venv
$ source .venv/bin/activate
$  pip install git+https://github.com/vasilvas99/unit_parse.git
$  python3 -c "import unit_parse" # no exceptions (successful import)
```
